### PR TITLE
Add environment-based backend URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # OperAID-Dev-Challenge
+
+## Frontend configuration
+
+The Angular client reads the backend URL from `src/environments/environment.ts`.
+The default points to `http://localhost:3000`:
+
+```ts
+export const environment = {
+  backendUrl: 'http://localhost:3000'
+};
+```
+
+Change `backendUrl` to match the address of your running API server.

--- a/frontend/src/app/core/socket.service.ts
+++ b/frontend/src/app/core/socket.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Socket } from 'ngx-socket-io';
+import { environment } from '../../environments/environment';
 import { map } from 'rxjs/operators';
 import { Observable } from 'rxjs';
 
@@ -8,7 +9,7 @@ export class SocketService extends Socket {
   mqtt$: Observable<{ topic: string; payload: { machineId: string; scrapIndex: number; value: number; timestamp: string }; ts: number }>;
 
   constructor() {
-    super({ url: 'http://localhost:3000', options: {} });
+    super({ url: environment.backendUrl, options: {} });
 
     this.mqtt$ = this.fromEvent<{ topic: string; payload: string }>('mqtt').pipe(
       map(msg => ({

--- a/frontend/src/environments/environment.ts
+++ b/frontend/src/environments/environment.ts
@@ -1,0 +1,3 @@
+export const environment = {
+  backendUrl: 'http://localhost:3000'
+};


### PR DESCRIPTION
## Summary
- add `src/environments/environment.ts`
- inject backend URL from environment
- document the new configuration

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852c1624bcc832b9b96928a06f6ab5b