### PR TITLE
Replace Promise.all with loop

### DIFF
--- a/backend/src/mqtt-publisher.js
+++ b/backend/src/mqtt-publisher.js
@@ -5,21 +5,21 @@ client.on('connect', () => {
     console.log('Publisher connected');
     setInterval(() => {
         const machines = ['A1', 'A2', 'A3'];
-        Promise.all(machines.map((machineId) => {
-            return new Promise((resolve) => {
-                const scrapIndex = Math.floor(Math.random() * 3) + 1; // 1, 2, or 3
-                const value = Math.random() * 3; // Range: 0 to 3
-                const payload = {
-                    machineId,
-                    scrapIndex,
-                    value,
-                    timestamp: new Date().toISOString(),
-                };
-                client.publish(`machines/${machineId}/scrap`, JSON.stringify(payload), () => {
-                    console.log('Published:', payload);
-                    resolve();
-                });
-            });
-        }));
+
+        machines.forEach((machineId) => {
+            const scrapIndex = Math.floor(Math.random() * 3) + 1; // 1, 2, or 3
+            const value = Math.random() * 3; // Range: 0 to 3
+            const payload = {
+                machineId,
+                scrapIndex,
+                value,
+                timestamp: new Date().toISOString(),
+            };
+            client.publish(
+                `machines/${machineId}/scrap`,
+                JSON.stringify(payload),
+                () => console.log('Published:', payload)
+            );
+        });
     }, 10000);
 });


### PR DESCRIPTION
## Summary
- refactor MQTT publisher to loop over machines instead of using `Promise.all`

## Testing
- `npm --prefix backend test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6852dc2bf028832b914cbcfc9f2f44f7