### PR TITLE
Add backend README and refine instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,20 @@
 # OperAID-Dev-Challenge
 
-## Prerequisites
+This repository contains a small demo stack consisting of a Node.js backend, an Angular frontend and a Mosquitto MQTT broker. The backend subscribes to MQTT topics and broadcasts metrics over WebSockets for the frontend dashboard.
 
-Before starting, ensure you have the following installed on your system:
+## Prerequisites
 
 - [Node.js](https://nodejs.org/) (includes npm)
 - [Mosquitto MQTT Broker](https://mosquitto.org/)
 
-## Installing Mosquitto
+### Installing Mosquitto
 
-### macOS
-
+#### macOS
 ```bash
 brew install mosquitto
 ```
 
-### Ubuntu/Debian
-
+#### Ubuntu/Debian
 ```bash
 sudo apt update
 sudo apt install mosquitto mosquitto-clients
@@ -24,65 +22,32 @@ sudo systemctl enable mosquitto
 sudo systemctl start mosquitto
 ```
 
-## Starting the Backend
+## Running the Entire Stack
 
-From the root directory, install dependencies and start the backend server:
-
+From the repository root install all dependencies and start every service (broker, backend, publisher and frontend) in parallel:
 ```bash
-npm install && npm run start
+npm install
+npm run start:all
 ```
 
-This command installs the required Node.js packages and starts the backend service.
-
-## Starting Individual Services
-
-If you prefer to start each service separately, use the following commands:
-
-### Backend
-
-From the root directory:
-
+To run only the broker, backend and publisher without the Angular dev server use:
 ```bash
-npm install && npm run start
+npm run start
 ```
 
-This starts the backend server.
+## Individual Services
 
-### Publisher
+Each service can be started separately if needed.
 
-From the root directory, run the MQTT publisher script:
+- **Backend** – see [backend/README.md](backend/README.md) for detailed instructions.
+- **Frontend** – from the root run `npm run start:frontend` or from the `frontend` directory run `ng serve`.
+- **Broker** – `mosquitto -c mosquitto/config/mosquitto.conf`.
+- **Publisher** – `npm --prefix backend run publisher` generates demo MQTT messages.
 
-```bash
-node src/mqtt-publisher.js
-```
+## Repository Structure
 
-This script publishes messages to the MQTT broker.
+- `backend/` – Node.js/TypeScript service bridging MQTT and WebSockets.
+- `frontend/` – Angular dashboard application.
+- `mosquitto/` – simple broker configuration.
 
-### Broker
 
-Start the Mosquitto broker with the custom configuration:
-
-```bash
-mosquitto -c mosquitto/config/mosquitto.conf
-```
-
-## Starting the Frontend
-
-### From the root directory
-
-Install dependencies and start the frontend development server:
-
-```bash
-npm install && npm run start:frontend
-```
-
-### From the frontend directory
-
-Alternatively, navigate to the frontend directory and run:
-
-```bash
-cd frontend
-npm install && ng serve
-```
-
-This will start the Angular development server for the frontend application.

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,48 @@
+# OperAID Node.js Backend
+
+This service subscribes to MQTT topics from production machines and exposes the data to clients via Socket.IO. It also provides a simple REST endpoint for health checks. The code is written in TypeScript.
+
+## Requirements
+
+- Node.js >=16
+- A running MQTT broker (e.g. Mosquitto)
+
+## Installation
+
+From this directory install dependencies:
+```bash
+npm install
+```
+
+## Running in Development
+
+Start the server with live reload using nodemon and ts-node:
+```bash
+npm run dev
+```
+
+## Running in Production
+
+Compile and launch the server:
+```bash
+npm run start
+```
+
+Optional environment variables:
+- `PORT` – HTTP/WebSocket port (default: 3000)
+- `MQTT_URL` – broker URL (default: `mqtt://localhost:1883`)
+
+## MQTT Publisher
+
+A demo publisher is provided to generate sample events:
+```bash
+npm run publisher
+```
+
+## Project Structure
+
+- `src/index.ts` – Express/Socket.IO server bridging MQTT messages.
+- `src/mqtt-publisher.js` – utility script that publishes random scrap events.
+- `tsconfig.json` – TypeScript configuration.
+
+


### PR DESCRIPTION
## Summary
- add documentation for Node backend
- simplify root README instructions and link to backend documentation

## Testing
- `npm test` *(fails: Missing script)*
- `npm --prefix backend test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68531fd618a8832b9e74052637d433c7