### PR TITLE
Add SlidingWindow unit test

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "dev": "nodemon --watch src --exec ts-node src/index.ts",
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "ts-node test/sliding-window.test.ts",
     "start": "ts-node src/index.ts",
     "publisher": "node src/mqtt-publisher.js"
   },

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -3,7 +3,7 @@ import http from 'http';
 import { Server } from 'socket.io';
 import mqtt from 'mqtt';
 
-class SlidingWindow {
+export class SlidingWindow {
   private buffer: ScrapEvent[] = [];
   constructor(private windowMs: number) {}
   add(event: ScrapEvent) {
@@ -104,6 +104,8 @@ app.get('/api/health', (_: Request, res: Response) => {
   res.json({ status: 'ok' });
 });
 
-/*Start servers */
-const PORT = Number(process.env.PORT) || 3000;
-server.listen(PORT, () => console.log(`HTTP+WS listening on :${PORT}`));
+/*Start servers only if run directly*/
+if (require.main === module) {
+  const PORT = Number(process.env.PORT) || 3000;
+  server.listen(PORT, () => console.log(`HTTP+WS listening on :${PORT}`));
+}

--- a/backend/test/sliding-window.test.ts
+++ b/backend/test/sliding-window.test.ts
@@ -1,0 +1,40 @@
+import assert from 'assert';
+import { SlidingWindow } from '../src/index';
+
+interface ScrapEvent {
+  machineId: string;
+  scrapIndex: number;
+  value: number;
+  timestamp: string;
+}
+
+function setNow(fake: number) {
+  const real = Date.now;
+  Date.now = () => fake;
+  return () => { Date.now = real; };
+}
+
+const base = Date.now();
+const sw = new SlidingWindow(60_000);
+
+let restore = setNow(base - 61_000);
+let res = sw.add({ machineId: 'm1', scrapIndex: 1, value: 10, timestamp: new Date(base - 61_000).toISOString() } as ScrapEvent);
+assert.deepStrictEqual(res, { sumLast60s: 10, avgLast60s: 10, countLast60s: 1 });
+restore();
+
+restore = setNow(base - 50_000);
+res = sw.add({ machineId: 'm1', scrapIndex: 1, value: 20, timestamp: new Date(base - 50_000).toISOString() } as ScrapEvent);
+assert.deepStrictEqual(res, { sumLast60s: 30, avgLast60s: 15, countLast60s: 2 });
+restore();
+
+restore = setNow(base - 10_000);
+res = sw.add({ machineId: 'm1', scrapIndex: 1, value: 30, timestamp: new Date(base - 10_000).toISOString() } as ScrapEvent);
+assert.deepStrictEqual(res, { sumLast60s: 60, avgLast60s: 20, countLast60s: 3 });
+restore();
+
+restore = setNow(base + 12_000);
+res = sw.add({ machineId: 'm1', scrapIndex: 1, value: 5, timestamp: new Date(base + 12_000).toISOString() } as ScrapEvent);
+assert.deepStrictEqual(res, { sumLast60s: 35, avgLast60s: 17.5, countLast60s: 2 });
+restore();
+
+console.log('SlidingWindow aggregation tests passed.');


### PR DESCRIPTION
## Summary
- export `SlidingWindow` class and guard server start in backend
- add basic `ts-node` based test for 60s sliding window aggregation
- wire up backend test script

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_6853d388fac8832bacb1f02baa7ac47b